### PR TITLE
Add bridge APIs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "igloohome-api"
-version = "0.0.6"
+version = "0.1.0"
 authors = [
     { name="keithle888", email="keithle888@gmail.com" },
 ]

--- a/src/igloohome-api/__init__.py
+++ b/src/igloohome-api/__init__.py
@@ -40,6 +40,25 @@ class GetDevicesResponse:
     payload: list[GetDeviceInfoResponse]
 
 
+@dataclass
+class CreateBridgeProxiedJobResponse:
+    jobId: str
+
+
+BRIDGE_JOB_LOCK = 1
+BRIDGE_JOB_UNLOCK = 2
+BRIDGE_JOB_CREATE_CUSTOM_PIN = 4
+BRIDGE_JOB_DELETE_CUSTOM_PIN = 5
+BRIDGE_JOB_GET_BATTERY_LEVEL = 9
+BRIDGE_JOB_GET_DEVICE_STATUS = 10
+BRIDGE_JOB_GET_ACTIVITY_LOGS = 15
+
+@dataclass
+class GetJobStatusResponse:
+    jobStatus: int
+    jobResponse: dict
+
+
 class Auth:
     def __init__(
             self,
@@ -141,6 +160,36 @@ class Api:
         )
         if response.status == 200:
             return from_dict(GetDeviceInfoResponse, await response.json())
+        else:
+            raise ApiException("Response failure", response.status)
+
+    async def create_bridge_proxied_job(
+            self,
+            deviceId: str,
+            bridgeId: str,
+            jobType: int,
+            jobData: dict = None
+    ) -> CreateBridgeProxiedJobResponse:
+        response = await self.auth.request(
+            "post",
+            f'{self.host}/{_BASE_PATH}/{_DEVICES_PATH_SEGMENT}/{deviceId}/jobs/bridges/{bridgeId}',
+            json={
+                "jobType": jobType,
+                "jobData": jobData,
+            }
+        )
+        if response.status == 200:
+            return from_dict(CreateBridgeProxiedJobResponse, await response.json())
+        else:
+            raise ApiException("Response failure", response.status)
+
+    async def get_job_status(self, jobId: str) -> GetJobStatusResponse:
+        response = await self.auth.request(
+            "get",
+            f'{self.host}/{_BASE_PATH}/jobs/{jobId}'
+        )
+        if response.status == 200:
+            return from_dict(GetJobStatusResponse, await response.json())
         else:
             raise ApiException("Response failure", response.status)
 

--- a/src/igloohome-api/__init__.py
+++ b/src/igloohome-api/__init__.py
@@ -9,7 +9,13 @@ from dataclasses import dataclass
 
 _OAUTH2_HOST = "https://auth.igloohome.co"
 _OAUTH2_TOKEN_PATH = "/oauth2/token"
-_OAUTH2_SCOPE_EVERYTHING = OAUTH2_SCOPE = "igloohomeapi/algopin-hourly igloohomeapi/algopin-daily igloohomeapi/algopin-permanent igloohomeapi/algopin-onetime igloohomeapi/create-pin-bridge-proxied-job igloohomeapi/delete-pin-bridge-proxied-job igloohomeapi/lock-bridge-proxied-job igloohomeapi/unlock-bridge-proxied-job igloohomeapi/get-devices igloohomeapi/get-job-status igloohomeapi/get-properties"
+_OAUTH2_SCOPE_EVERYTHING = OAUTH2_SCOPE = ("igloohomeapi/algopin-hourly igloohomeapi/algopin-daily "
+                                           "igloohomeapi/algopin-permanent igloohomeapi/algopin-onetime "
+                                           "igloohomeapi/create-pin-bridge-proxied-job "
+                                           "igloohomeapi/delete-pin-bridge-proxied-job "
+                                           "igloohomeapi/lock-bridge-proxied-job "
+                                           "igloohomeapi/unlock-bridge-proxied-job igloohomeapi/get-devices "
+                                           "igloohomeapi/get-job-status igloohomeapi/get-properties")
 
 _BASE_URL = "https://api.igloodeveloper.co"
 _BASE_PATH = "igloohome"

--- a/src/igloohome_api/__init__.py
+++ b/src/igloohome_api/__init__.py
@@ -68,6 +68,13 @@ BRIDGE_JOB_GET_BATTERY_LEVEL = 9
 BRIDGE_JOB_GET_DEVICE_STATUS = 10
 BRIDGE_JOB_GET_ACTIVITY_LOGS = 15
 
+"""One of the possible GetDeviceInfoResponse.type values."""
+DEVICE_TYPE_BRIDGE = "Bridge"
+"""One of the possible GetDeviceInfoResponse.type values."""
+DEVICE_TYPE_LOCK = "Lock"
+"""One of the possible GetDeviceInfoResponse.type values."""
+DEVICE_TYPE_KEYPAD = "Keypad"
+
 
 class Auth:
     def __init__(

--- a/src/igloohome_api/__init__.py
+++ b/src/igloohome_api/__init__.py
@@ -53,10 +53,11 @@ class CreateBridgeProxiedJobResponse:
 
 @dataclass
 class GetJobStatusResponse:
-    jobStatus: int
+    jobId: str
     expiryDate: str
     completed: bool
-    jobStatus: dict
+    jobType: str
+    jobResponse: dict
 
 
 BRIDGE_JOB_LOCK = 1

--- a/src/igloohome_api/__init__.py
+++ b/src/igloohome_api/__init__.py
@@ -51,6 +51,14 @@ class CreateBridgeProxiedJobResponse:
     jobId: str
 
 
+@dataclass
+class GetJobStatusResponse:
+    jobStatus: int
+    expiryDate: str
+    completed: bool
+    jobStatus: dict
+
+
 BRIDGE_JOB_LOCK = 1
 BRIDGE_JOB_UNLOCK = 2
 BRIDGE_JOB_CREATE_CUSTOM_PIN = 4
@@ -58,11 +66,6 @@ BRIDGE_JOB_DELETE_CUSTOM_PIN = 5
 BRIDGE_JOB_GET_BATTERY_LEVEL = 9
 BRIDGE_JOB_GET_DEVICE_STATUS = 10
 BRIDGE_JOB_GET_ACTIVITY_LOGS = 15
-
-@dataclass
-class GetJobStatusResponse:
-    jobStatus: int
-    jobResponse: dict
 
 
 class Auth:


### PR DESCRIPTION
# Added
- Added `CreateBridgeProxiedJobResponse` & `GetJobStatusResponse` data classes
- Added `Api.create_bridge_proxied_job()`
- Added `Api.get_job_status()`
- Added DEVICE_TYPE_* constants that reflect known types from GetDeviceInfoResponse.type
- Added BRIDGE_JOB_* constants for known jobs to be used with `Api.create_bridge_proxied_job()`

# Changed
- Version bump to v0.1.0